### PR TITLE
Setup event listener when document is ready

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,3 +45,7 @@ RSpec/DescribeClass:
 
 RSpec/NestedGroups:
   Enabled: false
+
+Rails/Date:
+  Exclude:
+    - 'spec/services/bolognese/readers/hyrax_work_reader_spec.rb'

--- a/app/views/hyrax/base/_form_doi.html.erb
+++ b/app/views/hyrax/base/_form_doi.html.erb
@@ -85,25 +85,27 @@
   // Force the user to confirm using fallback defaults when DataCite mandatory fields
   // not filled in on the deposit form.  This only applies when the DOI is set to become
   // registered or findable.  Let drafts be drafts.
-  document.getElementById('with_files_submit').addEventListener("click", function(event){
-    if (["findable", "registered"].indexOf(document.querySelector('input[name="generic_work[doi_status_when_public]"]:checked').value) < 0)
-      return;
+  $(document).ready(function() {
+    document.getElementById('with_files_submit').addEventListener("click", function(event){
+      if (["findable", "registered"].indexOf(document.querySelector('input[name="generic_work[doi_status_when_public]"]:checked').value) < 0)
+        return;
 
-    const empty_fields = [];
-    if (document.querySelector('.generic_work_title .form-control').value == "")
-      empty_fields.push("Title")
-    if (document.querySelector('.generic_work_creator .form-control').value == "")
-      empty_fields.push("Creator")
-    if (document.querySelector('.generic_work_publisher .form-control').value == "")
-      empty_fields.push("Publisher")
-    if (document.querySelector('.generic_work_date_created .form-control').value == "")
-      empty_fields.push("Date Created")
-    if (empty_fields.length == 0)
-      return;
+      const empty_fields = [];
+      if (document.querySelector('.generic_work_title .form-control').value == "")
+        empty_fields.push("Title")
+      if (document.querySelector('.generic_work_creator .form-control').value == "")
+        empty_fields.push("Creator")
+      if (document.querySelector('.generic_work_publisher .form-control').value == "")
+        empty_fields.push("Publisher")
+      if (document.querySelector('.generic_work_date_created .form-control').value == "")
+        empty_fields.push("Date Created")
+      if (empty_fields.length == 0)
+        return;
 
-    if(!window.confirm("DataCite DOI mandatory fields ("+ empty_fields.join(', ') +") are missing.  Placeholder values will be submitted to DataCite instead.  Do you want to proceed?")){
-      event.preventDefault();
-      event.stopImmediatePropagation();
-    }
-  }, false);
+      if(!window.confirm("DataCite DOI mandatory fields ("+ empty_fields.join(', ') +") are missing.  Placeholder values will be submitted to DataCite instead.  Do you want to proceed?")){
+        event.preventDefault();
+        event.stopImmediatePropagation();
+      }
+    }, false);
+  });
 </script>

--- a/spec/services/bolognese/readers/hyrax_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/hyrax_work_reader_spec.rb
@@ -121,7 +121,7 @@ describe Bolognese::Readers::HyraxWorkReader do
 
         context 'without either' do
           it 'defaults to current year' do
-            expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq "2020"
+            expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq Date.today.year.to_s
           end
         end
       end


### PR DESCRIPTION
This hopefully fixes a timing issue where this JS fires before the `with_files_submit` element exists.