### PR TITLE
Add a / to the end datacite production url

### DIFF
--- a/app/services/hyrax/doi/datacite_client.rb
+++ b/app/services/hyrax/doi/datacite_client.rb
@@ -6,7 +6,7 @@ module Hyrax
 
       TEST_BASE_URL = "https://api.test.datacite.org/"
       TEST_MDS_BASE_URL = "https://mds.test.datacite.org/"
-      PRODUCTION_BASE_URL = "https://api.datacite.org"
+      PRODUCTION_BASE_URL = "https://api.datacite.org/"
       PRODUCTION_MDS_BASE_URL = "https://mds.datacite.org/"
 
       def initialize(username:, password:, prefix:, mode: :production)

--- a/spec/services/hyrax/doi/datacite_client_spec.rb
+++ b/spec/services/hyrax/doi/datacite_client_spec.rb
@@ -128,4 +128,11 @@ describe 'Hyrax::DOI::DataCiteClient', :datacite_api do
       expect { client.register_url(unknown_doi, url) }.to raise_error(/Failed registering url for DOI/)
     end
   end
+
+  describe 'valid production url' do
+    it 'ends with a slash' do
+      let(:url) { Hyrax::DOI::DataCiteClient::PRODUCTION_BASE_URL }
+      expect(url.chars.last(1).first).to eq('/')
+    end
+  end
 end

--- a/spec/services/hyrax/doi/datacite_client_spec.rb
+++ b/spec/services/hyrax/doi/datacite_client_spec.rb
@@ -130,8 +130,9 @@ describe 'Hyrax::DOI::DataCiteClient', :datacite_api do
   end
 
   describe 'valid production url' do
+    let(:url) { Hyrax::DOI::DataCiteClient::PRODUCTION_BASE_URL }
+
     it 'ends with a slash' do
-      let(:url) { Hyrax::DOI::DataCiteClient::PRODUCTION_BASE_URL }
       expect(url.chars.last(1).first).to eq('/')
     end
   end


### PR DESCRIPTION
We are unable to mint doi when datacite is in production mode. In Rails console I saw that the production url did not have the ending slash. I created a Faraday client in rails console where the url had the ending slash and I was able to mint a draft doi.

This change fixes the url.