### PR TITLE
Move to_sym to accessor or it will cause errors on load

### DIFF
--- a/app/services/hyrax/doi/datacite_client.rb
+++ b/app/services/hyrax/doi/datacite_client.rb
@@ -13,7 +13,7 @@ module Hyrax
         @username = username
         @password = password
         @prefix = prefix
-        @mode = mode.to_sym
+        @mode = mode
       end
 
       # Mint a draft DOI without metadata or a url
@@ -126,12 +126,13 @@ module Hyrax
         }
       end
 
+      # Ensre that `mode` is not a string
       def base_url
-        mode == :production ? PRODUCTION_BASE_URL : TEST_BASE_URL
+        mode&.to_sym == :production ? PRODUCTION_BASE_URL : TEST_BASE_URL
       end
 
       def mds_base_url
-        mode == :production ? PRODUCTION_MDS_BASE_URL : TEST_MDS_BASE_URL
+        mode&.to_sym == :production ? PRODUCTION_MDS_BASE_URL : TEST_MDS_BASE_URL
       end
     end
   end


### PR DESCRIPTION
On Hyku Addons we were seeing tens of thousands of sentry errors caused by calling `mode.to_sym` within the initialize method. I believe this is caused by being blank on load and being set from class instance variables. To try and resolve this, i've moved the `to_sym` to the url helper methods where the variable should be already set. 