### PR TITLE
🐛 Ensuring we inject Hyrax::DOI views before Hyrax

### DIFF
--- a/lib/hyrax/doi/engine.rb
+++ b/lib/hyrax/doi/engine.rb
@@ -29,14 +29,12 @@ module Hyrax
         # Prepend our views in front of Hyrax but after the main app, so they have precedence
         # but can still be overridden
         my_engine_root = Hyrax::DOI::Engine.root.to_s
+        hyrax_engine_root = Hyrax::Engine.root.to_s
         paths = ActionController::Base.view_paths.collect(&:to_s)
-        hyrax_path = paths.detect { |path| path.match(/\/hyrax-[\d\.]+.*/) }
-        paths = if hyrax_path
-                  paths.insert(paths.index(hyrax_path), my_engine_root + '/app/views')
-                else
-                  paths.insert(0, my_engine_root + '/app/views')
-                end
-        ActionController::Base.view_paths = paths
+        hyrax_view_path = paths.detect { |path| path.match(%r{^#{hyrax_engine_root}}) }
+        paths.insert(paths.index(hyrax_view_path), File.join(my_engine_root, 'app', 'views')) if hyrax_view_path
+
+        ActionController::Base.view_paths = paths.uniq
       end
     end
   end


### PR DESCRIPTION
Prior to this commit, the logic for finding the Hyrax in the view path
was assuming a version number (e.g. `hyrax-2.`); however if the we
pinned Hyrax to a branch/sha then we might have `hyrax-a`.  The result
being that we pre-prended the view path into the application.  That
created the conditions where the `view_paths` first element might not
have been the application but instead a gem/engine.

Which means that the convention of overriding views in the application
would not work.

With this commit, we're using the Hyrax's engine's root to determine the
view path suffix.  Further, if Hyrax is not in the view path, we don't
again inject at the beginning of the list the Hyrax::DOI engine into the
view path.

Related to:

- https://github.com/scientist-softserv/palni-palci/pull/731
- https://github.com/samvera-labs/bulkrax/pull/855
- https://github.com/samvera-labs/allinson_flex/pull/122