### PR TITLE
[fix] Simple fix for Hyrax DOI controller for autofill to not hardcod…

### DIFF
--- a/app/controllers/hyrax/doi/hyrax_doi_controller.rb
+++ b/app/controllers/hyrax/doi/hyrax_doi_controller.rb
@@ -67,7 +67,6 @@ module Hyrax
       def hyrax_work_from_doi(doi)
         # TODO: generalize this
         meta = Bolognese::Metadata.new(input: doi,
-                                       from: "datacite",
                                        sandbox: use_sandbox)
         # Check that a record was actually loaded
         raise Hyrax::DOI::NotFoundError, "DOI (#{doi}) could not be found." if meta.blank? || meta.doi.blank?


### PR DESCRIPTION
The `from` key was hard-coded to `datacite`, i have removed this which allows the class to automatically determine the source based on the DOI format