### PR TITLE
Use the updated syntax for creating an authorized Faraday connection. Fixes "NoMethodError: undefined method 'basic_auth'".

### DIFF
--- a/app/services/hyrax/doi/datacite_client.rb
+++ b/app/services/hyrax/doi/datacite_client.rb
@@ -103,14 +103,14 @@ module Hyrax
 
       def connection
         Faraday.new(url: base_url) do |c|
-          c.basic_auth(username, password)
+          c.try(:basic_auth) ? c.basic_auth(username, password) : c.request(:authorization, :basic, username, password)
           c.adapter(Faraday.default_adapter)
         end
       end
 
       def mds_connection
         Faraday.new(url: mds_base_url) do |c|
-          c.basic_auth(username, password)
+          c.try(:basic_auth) ? c.basic_auth(username, password) : c.request(:authorization, :basic, username, password)
           c.adapter(Faraday.default_adapter)
         end
       end


### PR DESCRIPTION
The basic_auth method on a Faraday connection has been deprecated for a while. This causes a NoMethodError when trying to connect to DataCite wtih a later version of Faraday:

```
NoMethodError: undefined method `basic_auth' for #<Faraday::Connection:0x...>
[[GEM_ROOT]/bundler/gems/hyrax-doi-9b7ab7f8054a/app/services/hyrax/doi/datacite_client.rb:106 :in `block in connection`
[[GEM_ROOT]/gems/faraday-2.8.1/lib/faraday/connection.rb:91 :in `initialize`
[[GEM_ROOT]/gems/faraday-2.8.1/lib/faraday.rb:98 :in `new`
[[GEM_ROOT]/gems/faraday-2.8.1/lib/faraday.rb:98 :in `new`
[[GEM_ROOT]/bundler/gems/hyrax-doi-9b7ab7f8054a/app/services/hyrax/doi/datacite_client.rb:105 :in `connection`
```

This commit lets downstream apps use the 2.x syntax described in the [Faraday documentation](https://lostisland.github.io/faraday/#/middleware/included/authentication?id=basic-authentication).